### PR TITLE
http_client: Manually construct query parameters for websocket connections

### DIFF
--- a/swaggerpy/http_client.py
+++ b/swaggerpy/http_client.py
@@ -195,6 +195,12 @@ class SynchronousHttpClient(HttpClient):
                   if k == 'Authorization']
         # Pull the URL, which includes query params
         url = preped_req.url
+        # Requests version 2.0.0 (at least) will no longer form a URL for us
+        # for ws scheme types, so we do it manually
+        if params:
+            joined_params = "&".join(["%s=%s" % (k, v)
+                                     for (k, v) in params.items()])
+            url += "?%s" % joined_params
         return websocket.create_connection(url, header=header)
 
     def apply_authentication(self, req):


### PR DESCRIPTION
The requests library, for versions 2.0.0 and greater (at least), will not
construct a URL for a scheme that does not begin with 'http'. For our
websocket connections, this means that a request object cannot be prepared,
as the PreparedRequest prepare method will simply return the URL in the
original request object.

This patch works around this by manually constructing the query parameters
from the passed in dictionary.
