### PR TITLE
Properly quote paths within HTTP URLs.

### DIFF
--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -64,7 +64,8 @@ class Operation(object):
 
             if value:
                 if param['paramType'] == 'path':
-                    uri = uri.replace('{%s}' % pname, str(value))
+                    uri = uri.replace('{%s}' % pname,
+                                      urllib.quote_plus(str(value)))
                 elif param['paramType'] == 'query':
                     params[pname] = value
                 else:


### PR DESCRIPTION
The change makes it so that parameters that are of type "path" get
quoted so that the HTTP server can properly parse it. The big
difference I found is that strings like:

foo/bar/baz

get changed to:

foo%2Fbar%2Fbaz

and improved behavior for me.
