### PR TITLE
swaggerpy/client.py: Fix spurious exception when default value is 0

### DIFF
--- a/swaggerpy/client.py
+++ b/swaggerpy/client.py
@@ -62,7 +62,7 @@ class Operation(object):
             if isinstance(value, list):
                 value = ",".join(value)
 
-            if value:
+            if value is not None:
                 if param['paramType'] == 'path':
                     uri = uri.replace('{%s}' % pname, str(value))
                 elif param['paramType'] == 'query':


### PR DESCRIPTION
If a required parameter has a value that is logically False - such as 0 -
the test for the existance of the required value will always fail, even
if the user has provided a value.

This patch fixes this by testing specifically for None. If the user fails
to provide a required parameter, this will correctly throw the exception;
otherwise, it will use the value provided (even if that value is 0 or
False).
