### PR TITLE
Added support for body parameters in operations when using HTTP

### DIFF
--- a/swaggerpy/http_client.py
+++ b/swaggerpy/http_client.py
@@ -166,14 +166,14 @@ class SynchronousHttpClient(HttpClient):
         self.authenticator = ApiKeyAuthenticator(
             host=host, api_key=api_key, param_name=param_name)
 
-    def request(self, method, url, params=None, data=None):
+    def request(self, method, url, params=None, data=None, headers=None):
         """Requests based implementation.
 
         :return: Requests response
         :rtype:  requests.Response
         """
         req = requests.Request(
-            method=method, url=url, params=params, data=data)
+            method=method, url=url, params=params, data=data, headers=headers)
         self.apply_authentication(req)
         return self.session.send(self.session.prepare_request(req))
 


### PR DESCRIPTION
This PR addresses asterisk/ari-py#10 - it adds support for body parameters in operations, only for HTTP requests (as opposed to websocket connections).